### PR TITLE
Add convert subcommand

### DIFF
--- a/src/rhoknp/cli/cli.py
+++ b/src/rhoknp/cli/cli.py
@@ -49,6 +49,31 @@ def cat(
     print_document(doc, is_dark=dark)
 
 
+@app.command(help="Convert a KNP file into raw text, Juman++ format, or KNP format.")
+def convert(
+    knp_path: Optional[Path] = typer.Argument(
+        None, exists=True, dir_okay=False, help="Path to knp file to convert. If not given, read from stdin"
+    ),
+    format_: str = typer.Option("text", "--format", "-f", help="Format to convert to."),
+) -> None:
+    """KNP ファイルを種々のフォーマットに変換．
+
+    Args:
+        knp_path: KNP ファイルのパス．
+        format_: 変換先のフォーマット．"text", "jumanpp", "knp" のいずれか．
+    """
+    knp_text = sys.stdin.read() if knp_path is None else knp_path.read_text()
+    doc = Document.from_knp(knp_text)
+    if format_ == "text":
+        print(doc.text)
+    elif format_ == "jumanpp":
+        print(doc.to_jumanpp(), end="")
+    elif format_ == "knp":
+        print(doc.to_knp(), end="")
+    else:
+        raise ValueError(f"Unknown format: {format_}")
+
+
 @app.command(help="Print given file content in tree format.")
 def show(
     knp_path: Path = typer.Argument(..., exists=True, dir_okay=False, help="Path to knp file to show"),

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -79,6 +79,15 @@ def test_convert_stdin() -> None:
         assert result.exit_code == 0
 
 
+def test_convert_value_error() -> None:
+    doc = Document.from_knp(knp_text)
+    with tempfile.NamedTemporaryFile("wt") as f:
+        f.write(doc.to_knp())
+        f.flush()
+        result = runner.invoke(app, ["convert", f.name, "--format", "foo"])  # Unknown format
+        assert result.exit_code == 1
+
+
 def test_show() -> None:
     doc = Document.from_knp(knp_text)
     with tempfile.NamedTemporaryFile("wt") as f:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -62,6 +62,23 @@ def test_cat_stdin() -> None:
     assert result.exit_code == 0
 
 
+def test_convert() -> None:
+    doc = Document.from_knp(knp_text)
+    with tempfile.NamedTemporaryFile("wt") as f:
+        f.write(doc.to_knp())
+        f.flush()
+        for format_ in ("text", "jumanpp", "knp"):
+            result = runner.invoke(app, ["convert", f.name, "--format", format_])
+            assert result.exit_code == 0
+
+
+@pytest.mark.usefixtures("_mock_stdin")
+def test_convert_stdin() -> None:
+    for format_ in ("text", "jumanpp", "knp"):
+        result = runner.invoke(app, ["convert", "--format", format_])
+        assert result.exit_code == 0
+
+
 def test_show() -> None:
     doc = Document.from_knp(knp_text)
     with tempfile.NamedTemporaryFile("wt") as f:


### PR DESCRIPTION
# What

`rhoknp convert [knp_file] [--format FORMAT]` converts a given KNP file into raw text, Juman++ format, or KNP format.

```shell
$ rhoknp convert <(echo こんにちは | jumanpp | knp -tab) --format text
こんにちは
```